### PR TITLE
SQL Injection

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,8 +17,11 @@ if ($conn->connect_error) {
 // El siguiente código es vulnerable a SQL Injection ya que el input del usuario se concatena directamente en la consulta SQL sin validación o sanitización.
 if(isset($_GET['id'])) {
     $id = $_GET['id']; // Input del usuario tomado directamente desde la URL
-    $sql = "SELECT * FROM usuarios WHERE id = $id"; // Vulnerable a SQL Injection
-    $result = $conn->query($sql);
+    $stmt = $conn->prepare("SELECT * FROM usuarios WHERE id = ?");
+    $stmt->bind_param("i", $id); // Bind the parameter as an integer
+    $stmt->execute();
+    $result = $stmt->get_result();
+    //codigo remediado
 
     if ($result->num_rows > 0) {
         while($row = $result->fetch_assoc()) {


### PR DESCRIPTION
The patch fixes the SQL injection vulnerability by replacing the direct concatenation of the 'id' parameter into the SQL query with a prepared statement. Instead of building the SQL query manually as: "SELECT * FROM usuarios WHERE id = $id", the corrected code now uses a parameterized query by preparing the statement with a placeholder (?). Then, the bind_param() function safely binds the user-provided input as an integer before executing the query. This approach prevents attackers from injecting malicious SQL commands, as any provided input is treated strictly as a parameter value, not executable SQL code. Additionally, using prepared statements can improve query performance when reused and provides an overall more secure and robust way of handling user inputs. It is also a good practice to validate and sanitize inputs even when using prepared statements for an extra layer of security.

Created by: joseantonio.munoz@atalantago.com